### PR TITLE
Fix mobile landing page

### DIFF
--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -297,7 +297,8 @@ const postText = (small?: boolean) =>
     fontFamily('font-primary'),
     fontSize({ 'text-sm': small }),
     lineHeight(small ? 'leading-5' : 'leading-6'),
-    whitespace('whitespace-pre-wrap')
+    whitespace('whitespace-pre-wrap'),
+    wordBreak('break-all')
   )
 export function PostText({
   small,


### PR DESCRIPTION
- post with a huge link broke UI
- added `break` class to fix it
