### PR TITLE
Safari fix gradient text

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -32,6 +32,7 @@ import {
 } from 'classnames/tailwind'
 import Arrow from 'icons/Arrow'
 import Loading from 'icons/Loading'
+import classNamesToString from 'helpers/classNamesToString'
 
 const commonClasses = ({
   type,
@@ -53,6 +54,7 @@ const commonClasses = ({
   heightFit?: boolean
 }) => {
   const isNotTertiary = type !== 'tertiary'
+
   return classnames(
     display('flex'),
     gap('gap-x-2'),
@@ -174,6 +176,8 @@ const textGradient = (available?: boolean) =>
     backgroundImage('bg-gradient-to-r'),
     gradientColorStops('from-secondary', 'to-accent')
   )
+const textGradientClasses = (available?: boolean) =>
+  classNamesToString(textGradient(available), 'clip-background')
 
 interface ButtonProps {
   type: ButtonType
@@ -233,7 +237,7 @@ export default function ({
       {showContent && (
         <>
           {gradientFont ? (
-            <span className={textGradient(available)}>{children}</span>
+            <span className={textGradientClasses(available)}>{children}</span>
           ) : (
             <>{children}</>
           )}

--- a/src/helpers/classNamesToString.ts
+++ b/src/helpers/classNamesToString.ts
@@ -13,6 +13,7 @@ type AllowedExtraClassnames =
   | 'stroke-text-secondary'
   | 'empty:hidden'
   | 'colorful-gradient'
+  | 'clip-background'
 
 export default function (
   ...classNames: (AllowedExtraClassnames | TTailwindString | undefined | null)[]

--- a/src/index.css
+++ b/src/index.css
@@ -164,6 +164,11 @@ circle {
   box-shadow: inset 0rem 0rem 0.5rem 0 var(--light-formal-accent);
 }
 
+.clip-background {
+  clip-path: inset(1px);
+  padding: 1px;
+}
+
 .animated-border::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
- added `clip-path` to the button with gradient font
- added extra 1px padding to prevent cutting clipped text
- added a new class
---------
Checked in Safari, Firefox & Chrome. Everywhere it looks like in the design without extra borders in the button
